### PR TITLE
Control sticky contact visibility with shelf and menu

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1334,11 +1334,9 @@ p {
   height: 20px;
 }
 
-/* When the slide-out nav (shelf) is open, keep the FAB distinct by moving it left */
-/* Ensure the FAB always stays bottom-right, even when nav is open */
+/* When the slide-out nav (shelf) is open, hide the FAB */
 .nav-open .contact-fab {
-  left: auto;
-  right: 18px;
+  display: none;
 }
 
 /* Respect user preferences for reduced motion */


### PR DESCRIPTION
Hide the sticky contact button when the mobile navigation shelf is open.

---
<a href="https://cursor.com/background-agent?bcId=bc-c1e98dd3-980f-4c98-85c5-a54ee14c4f57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c1e98dd3-980f-4c98-85c5-a54ee14c4f57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

