### PR TITLE
Adjust apply now section layout

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1226,6 +1226,12 @@ p {
   margin-top: 2rem;
 }
 
+/* Align the apply CTA inside career card with body text */
+.card .apply-cta {
+  text-align: left;
+  margin-top: 0.5rem;
+}
+
 /* Responsive adjustments */
 @media (max-width: 767px) {
   .hero-ctas {

--- a/career.html
+++ b/career.html
@@ -70,29 +70,9 @@
           <aside class="card" aria-labelledby="apply-now">
             <h3 id="apply-now">Apply now</h3>
             <p class="muted">Email your CV and a short cover letter to:</p>
-            <div class="apply-cta">
+            <div class="apply-cta" style="text-align: left; margin-top: 0.5rem;">
               <a class="btn btn-primary" href="mailto:careers@vallalar.edu.in?subject=Application%20for%20%5BRole%5D">Email: careers@vallalar.edu.in</a>
             </div>
-            <p class="muted" style="margin-top: 1rem;">Or use the form below (optional):</p>
-
-            <form class="form" action="#" onsubmit="event.preventDefault();alert('Please email your CV to careers@vallalar.edu.in');" aria-label="apply form">
-              <div class="form-field">
-                <label for="name">Name</label>
-                <input id="name" name="name" type="text" required />
-              </div>
-              <div class="form-field">
-                <label for="role">Role applying for</label>
-                <input id="role" name="role" type="text" required />
-              </div>
-              <div class="form-field">
-                <label for="email">Email</label>
-                <input id="email" name="email" type="email" required />
-              </div>
-              <div class="form-actions">
-                <button class="btn btn-primary" type="submit">Submit (or email CV)</button>
-              </div>
-            </form>
-
             <p class="muted small" style="margin-top: 1rem;">Address: [Institution Address]<br />Phone: [Contact Number]</p>
           </aside>
         </div>


### PR DESCRIPTION
Remove the "use the form below" section and its form from the "Apply now" card, and align the email CTA to improve its visual integration.

---
<a href="https://cursor.com/background-agent?bcId=bc-50615df3-4b8e-49d4-98e2-7ad10b5522f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-50615df3-4b8e-49d4-98e2-7ad10b5522f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

