### PR TITLE
Remove extra fields from apply now

### DIFF
--- a/career.html
+++ b/career.html
@@ -67,13 +67,10 @@
             <p class="muted">Send CV + cover letter → Shortlist → Interview / demo class → Offer &amp; induction</p>
           </div>
 
-          <aside class="card" aria-labelledby="apply-now">
-            <h3 id="apply-now">Apply now</h3>
-            <p class="muted">Email your CV and a short cover letter to:</p>
+          <aside class="card">
             <div class="apply-cta" style="text-align: left; margin-top: 0.5rem;">
               <a class="btn btn-primary" href="mailto:careers@vallalar.edu.in?subject=Application%20for%20%5BRole%5D">Email: careers@vallalar.edu.in</a>
             </div>
-            <p class="muted small" style="margin-top: 1rem;">Address: [Institution Address]<br />Phone: [Contact Number]</p>
           </aside>
         </div>
       </section>


### PR DESCRIPTION
Remove all content from the "Apply now" section except the email link, as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-708f4733-e4eb-425e-bfe0-8ff02f54fe2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-708f4733-e4eb-425e-bfe0-8ff02f54fe2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

